### PR TITLE
fix codeql badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RevloDB
 
 [![Super-Linter](https://github.com/chaitanyamand/RevloDB/actions/workflows/linter.yml/badge.svg)](https://github.com/chaitanyamand/RevloDB/actions/workflows/linter.yml)
-[![CodeQL](https://github.com/chaitanyamand/RevloDB/actions/workflows/codeql.yml/badge.svg)](https://github.com/chaitanyamand/RevloDB/actions/workflows/codeql.yml)
+[![CodeQL](https://github.com/chaitanyamand/RevloDB/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/chaitanyamand/RevloDB/actions/workflows/github-code-scanning/codeql)
 [![Reviewed by CodeRabbit](https://img.shields.io/badge/Reviewed%20by-CodeRabbit-0094F5?logo=coderabbit)](https://coderabbit.ai)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README badge to use GitHub Code Scanning instead of the CodeQL workflow. The badge now reflects repository-wide code scanning status and links to the security analysis page, improving visibility of security checks for users and contributors. No user-facing functionality or API changes. Low-risk, documentation-only update. No build, test, or runtime impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->