### PR TITLE
Add soft-delete mechanism and reverting to specific version functionality

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,5 +23,4 @@ jobs:
         uses: github/super-linter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LOG_LEVEL: debug
           DEFAULT_BRANCH: main

--- a/api/Configurations/CleanupJobOptions.cs
+++ b/api/Configurations/CleanupJobOptions.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace RevloDB.Configuration
+{
+    public class CleanupJobOptions
+    {
+        public const string SectionName = "CleanupJob";
+
+        [Required]
+        public bool Enabled { get; set; } = true;
+
+        [Range(1, 24)]
+        [Required]
+        public int IntervalHours { get; set; } = 24;
+
+        [Range(1, 60)]
+        [Required]
+        public int StartDelayMinutes { get; set; } = 5;
+
+        [Required]
+        public bool LogDetailedInfo { get; set; } = true;
+    }
+}

--- a/api/Controllers/KeyValueControllers.cs
+++ b/api/Controllers/KeyValueControllers.cs
@@ -97,6 +97,18 @@ namespace RevloDB.Controllers
             return NoContent();
         }
 
+        [HttpPost("{keyName}/restore")]
+        public async Task<IActionResult> RestoreKey(string keyName)
+        {
+            if (string.IsNullOrWhiteSpace(keyName))
+            {
+                return this.BadRequestProblem("Key name cannot be empty");
+            }
+
+            await _keyValueService.RestoreKeyAsync(keyName);
+            return NoContent();
+        }
+
         [HttpGet("{keyName}/history")]
         public async Task<ActionResult<IEnumerable<VersionDto>>> GetKeyHistory(string keyName)
         {
@@ -107,6 +119,18 @@ namespace RevloDB.Controllers
 
             var versions = await _keyValueService.GetKeyHistoryAsync(keyName);
             return Ok(versions);
+        }
+
+        [HttpPost("revert")]
+        public async Task<ActionResult<KeyDto>> RevertToVersion([FromBody] RevertKeyDto revertKeyDto)
+        {
+            if (!ModelState.IsValid)
+            {
+                return this.ModelValidationProblem(ModelState);
+            }
+
+            var key = await _keyValueService.RevertKeyAsync(revertKeyDto);
+            return Ok(key);
         }
 
         [HttpGet("{keyName}/version/{versionNumber}")]

--- a/api/DTOs/KeyDTO.cs
+++ b/api/DTOs/KeyDTO.cs
@@ -29,4 +29,16 @@ namespace RevloDB.DTOs
         [StringLength(1000, MinimumLength = 1, ErrorMessage = "Value cannot be empty")]
         public string Value { get; set; } = string.Empty;
     }
+
+    public class RevertKeyDto
+    {
+        [Required(ErrorMessage = "Key name cannot be empty")]
+        [MinLength(3, ErrorMessage = "Key name must be at least 3 characters long")]
+        [MaxLength(100, ErrorMessage = "Key name cannot exceed 100 characters")]
+        public string KeyName { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Version number is required")]
+        [Range(1, int.MaxValue, ErrorMessage = "Version number must be a positive integer")]
+        public int VersionNumber { get; set; } = 0;
+    }
 }

--- a/api/DTOs/KeyDTO.cs
+++ b/api/DTOs/KeyDTO.cs
@@ -39,6 +39,6 @@ namespace RevloDB.DTOs
 
         [Required(ErrorMessage = "Version number is required")]
         [Range(1, int.MaxValue, ErrorMessage = "Version number must be a positive integer")]
-        public int VersionNumber { get; set; } = 0;
+        public int? VersionNumber { get; set; }
     }
 }

--- a/api/Data/DBContext.cs
+++ b/api/Data/DBContext.cs
@@ -4,74 +4,74 @@ using Key = RevloDB.Entities.Key;
 
 namespace RevloDB.Data
 {
-      public class RevloDbContext : DbContext
-      {
-            public RevloDbContext(DbContextOptions<RevloDbContext> options) : base(options)
+    public class RevloDbContext : DbContext
+    {
+        public RevloDbContext(DbContextOptions<RevloDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<Key> Keys { get; set; }
+        public DbSet<Version> Versions { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Key>(entity =>
             {
-            }
+                entity.ToTable("keys");
 
-            public DbSet<Key> Keys { get; set; }
-            public DbSet<Version> Versions { get; set; }
+                entity.HasIndex(k => k.CurrentVersionId)
+                      .HasDatabaseName("ix_keys_current_version_id");
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                entity.HasIndex(k => k.KeyName)
+                      .IsUnique()
+                      .HasDatabaseName("ix_keys_key_name");
+
+                entity.HasIndex(k => k.IsDeleted)
+                      .HasFilter("is_deleted = TRUE")
+                      .HasDatabaseName("ix_keys_is_deleted_true");
+
+                entity.Property(k => k.Id).HasColumnName("id");
+                entity.Property(k => k.KeyName).HasColumnName("key_name");
+                entity.Property(k => k.CurrentVersionId).HasColumnName("current_version_id");
+                entity.Property(k => k.CreatedAt).HasColumnName("created_at");
+                entity.Property(k => k.IsDeleted).HasColumnName("is_deleted");
+
+                entity.Property(k => k.CreatedAt)
+                      .HasDefaultValueSql("NOW()");
+            });
+
+            modelBuilder.Entity<Version>(entity =>
             {
-                  base.OnModelCreating(modelBuilder);
+                entity.ToTable("versions");
 
-                  modelBuilder.Entity<Key>(entity =>
-                  {
-                        entity.ToTable("keys");
+                entity.HasIndex(v => new { v.KeyId, v.VersionNumber })
+                      .IsUnique()
+                      .HasDatabaseName("ix_versions_key_id_version_number");
 
-                        entity.HasIndex(k => k.CurrentVersionId)
-                        .HasDatabaseName("ix_keys_current_version_id");
+                entity.Property(v => v.Id).HasColumnName("id");
+                entity.Property(v => v.Value).HasColumnName("value");
+                entity.Property(v => v.Timestamp).HasColumnName("timestamp");
+                entity.Property(v => v.VersionNumber).HasColumnName("version_number");
+                entity.Property(v => v.KeyId).HasColumnName("key_id");
 
-                        entity.HasIndex(k => k.KeyName)
-                        .IsUnique()
-                        .HasDatabaseName("ix_keys_key_name");
+                entity.Property(v => v.Timestamp)
+                      .HasDefaultValueSql("NOW()");
 
-                        entity.HasIndex(k => k.IsDeleted)
-                        .HasFilter("is_deleted = TRUE")
-                        .HasDatabaseName("ix_keys_is_deleted_true");
+                entity.HasOne(v => v.Key)
+                      .WithMany(k => k.Versions)
+                      .HasForeignKey(v => v.KeyId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("fk_versions_keys_key_id");
+            });
 
-                        entity.Property(k => k.Id).HasColumnName("id");
-                        entity.Property(k => k.KeyName).HasColumnName("key_name");
-                        entity.Property(k => k.CurrentVersionId).HasColumnName("current_version_id");
-                        entity.Property(k => k.CreatedAt).HasColumnName("created_at");
-                        entity.Property(k => k.IsDeleted).HasColumnName("is_deleted");
-
-                        entity.Property(k => k.CreatedAt)
-                        .HasDefaultValueSql("NOW()");
-                  });
-
-                  modelBuilder.Entity<Version>(entity =>
-                  {
-                        entity.ToTable("versions");
-
-                        entity.HasIndex(v => new { v.KeyId, v.VersionNumber })
-                        .IsUnique()
-                        .HasDatabaseName("ix_versions_key_id_version_number");
-
-                        entity.Property(v => v.Id).HasColumnName("id");
-                        entity.Property(v => v.Value).HasColumnName("value");
-                        entity.Property(v => v.Timestamp).HasColumnName("timestamp");
-                        entity.Property(v => v.VersionNumber).HasColumnName("version_number");
-                        entity.Property(v => v.KeyId).HasColumnName("key_id");
-
-                        entity.Property(v => v.Timestamp)
-                        .HasDefaultValueSql("NOW()");
-
-                        entity.HasOne(v => v.Key)
-                        .WithMany(k => k.Versions)
-                        .HasForeignKey(v => v.KeyId)
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .HasConstraintName("fk_versions_keys_key_id");
-                  });
-
-                  modelBuilder.Entity<Key>()
-                      .HasOne(k => k.CurrentVersion)
-                      .WithMany()
-                      .HasForeignKey(k => k.CurrentVersionId)
-                      .OnDelete(DeleteBehavior.SetNull)
-                      .HasConstraintName("fk_keys_versions_current_version_id");
-            }
-      }
+            modelBuilder.Entity<Key>()
+                .HasOne(k => k.CurrentVersion)
+                .WithMany()
+                .HasForeignKey(k => k.CurrentVersionId)
+                .OnDelete(DeleteBehavior.SetNull)
+                .HasConstraintName("fk_keys_versions_current_version_id");
+        }
+    }
 }

--- a/api/Data/DBContext.cs
+++ b/api/Data/DBContext.cs
@@ -4,69 +4,74 @@ using Key = RevloDB.Entities.Key;
 
 namespace RevloDB.Data
 {
-    public class RevloDbContext : DbContext
-    {
-        public RevloDbContext(DbContextOptions<RevloDbContext> options) : base(options)
-        {
-        }
-
-        public DbSet<Key> Keys { get; set; }
-        public DbSet<Version> Versions { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<Key>(entity =>
+      public class RevloDbContext : DbContext
+      {
+            public RevloDbContext(DbContextOptions<RevloDbContext> options) : base(options)
             {
-                entity.ToTable("keys");
+            }
 
-                entity.HasIndex(k => k.CurrentVersionId)
-                      .HasDatabaseName("ix_keys_current_version_id");
+            public DbSet<Key> Keys { get; set; }
+            public DbSet<Version> Versions { get; set; }
 
-                entity.HasIndex(k => k.KeyName)
-                      .IsUnique()
-                      .HasDatabaseName("ix_keys_key_name");
-
-                entity.Property(k => k.Id).HasColumnName("id");
-                entity.Property(k => k.KeyName).HasColumnName("key_name");
-                entity.Property(k => k.CurrentVersionId).HasColumnName("current_version_id");
-                entity.Property(k => k.CreatedAt).HasColumnName("created_at");
-
-                entity.Property(k => k.CreatedAt)
-                      .HasDefaultValueSql("NOW()");
-            });
-
-            modelBuilder.Entity<Version>(entity =>
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                entity.ToTable("versions");
+                  base.OnModelCreating(modelBuilder);
 
-                entity.HasIndex(v => new { v.KeyId, v.VersionNumber })
-                      .IsUnique()
-                      .HasDatabaseName("ix_versions_key_id_version_number");
+                  modelBuilder.Entity<Key>(entity =>
+                  {
+                        entity.ToTable("keys");
 
-                entity.Property(v => v.Id).HasColumnName("id");
-                entity.Property(v => v.Value).HasColumnName("value");
-                entity.Property(v => v.Timestamp).HasColumnName("timestamp");
-                entity.Property(v => v.VersionNumber).HasColumnName("version_number");
-                entity.Property(v => v.KeyId).HasColumnName("key_id");
+                        entity.HasIndex(k => k.CurrentVersionId)
+                        .HasDatabaseName("ix_keys_current_version_id");
 
-                entity.Property(v => v.Timestamp)
-                      .HasDefaultValueSql("NOW()");
+                        entity.HasIndex(k => k.KeyName)
+                        .IsUnique()
+                        .HasDatabaseName("ix_keys_key_name");
 
-                entity.HasOne(v => v.Key)
-                      .WithMany(k => k.Versions)
-                      .HasForeignKey(v => v.KeyId)
-                      .OnDelete(DeleteBehavior.Cascade)
-                      .HasConstraintName("fk_versions_keys_key_id");
-            });
+                        entity.HasIndex(k => k.IsDeleted)
+                        .HasFilter("is_deleted = TRUE")
+                        .HasDatabaseName("ix_keys_is_deleted_true");
 
-            modelBuilder.Entity<Key>()
-                .HasOne(k => k.CurrentVersion)
-                .WithMany()
-                .HasForeignKey(k => k.CurrentVersionId)
-                .OnDelete(DeleteBehavior.SetNull)
-                .HasConstraintName("fk_keys_versions_current_version_id");
-        }
-    }
+                        entity.Property(k => k.Id).HasColumnName("id");
+                        entity.Property(k => k.KeyName).HasColumnName("key_name");
+                        entity.Property(k => k.CurrentVersionId).HasColumnName("current_version_id");
+                        entity.Property(k => k.CreatedAt).HasColumnName("created_at");
+                        entity.Property(k => k.IsDeleted).HasColumnName("is_deleted");
+
+                        entity.Property(k => k.CreatedAt)
+                        .HasDefaultValueSql("NOW()");
+                  });
+
+                  modelBuilder.Entity<Version>(entity =>
+                  {
+                        entity.ToTable("versions");
+
+                        entity.HasIndex(v => new { v.KeyId, v.VersionNumber })
+                        .IsUnique()
+                        .HasDatabaseName("ix_versions_key_id_version_number");
+
+                        entity.Property(v => v.Id).HasColumnName("id");
+                        entity.Property(v => v.Value).HasColumnName("value");
+                        entity.Property(v => v.Timestamp).HasColumnName("timestamp");
+                        entity.Property(v => v.VersionNumber).HasColumnName("version_number");
+                        entity.Property(v => v.KeyId).HasColumnName("key_id");
+
+                        entity.Property(v => v.Timestamp)
+                        .HasDefaultValueSql("NOW()");
+
+                        entity.HasOne(v => v.Key)
+                        .WithMany(k => k.Versions)
+                        .HasForeignKey(v => v.KeyId)
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .HasConstraintName("fk_versions_keys_key_id");
+                  });
+
+                  modelBuilder.Entity<Key>()
+                      .HasOne(k => k.CurrentVersion)
+                      .WithMany()
+                      .HasForeignKey(k => k.CurrentVersionId)
+                      .OnDelete(DeleteBehavior.SetNull)
+                      .HasConstraintName("fk_keys_versions_current_version_id");
+            }
+      }
 }

--- a/api/Entities/Key.cs
+++ b/api/Entities/Key.cs
@@ -16,5 +16,6 @@ namespace RevloDB.Entities
         [ForeignKey("CurrentVersionId")]
         public Version? CurrentVersion { get; set; }
         public ICollection<Version> Versions { get; set; } = new List<Version>();
+        public bool IsDeleted { get; set; } = false;
     }
 }

--- a/api/Extensions/ServiceCollectionExtensions.cs
+++ b/api/Extensions/ServiceCollectionExtensions.cs
@@ -19,6 +19,12 @@ namespace RevloDB.Extensions
                 .ValidateDataAnnotations()
                 .ValidateOnStart();
 
+            services
+                .AddOptions<CleanupJobOptions>()
+                .Bind(configuration.GetSection(CleanupJobOptions.SectionName))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
             services.AddDbContext<RevloDbContext>((serviceProvider, options) =>
             {
                 var connectionString = configuration.GetConnectionString("DefaultConnection")
@@ -44,6 +50,8 @@ namespace RevloDB.Extensions
             services.AddScoped<IKeyValueService, KeyValueService>();
 
             services.AddScoped<IDatabaseInitializerService, DatabaseInitializerService>();
+            services.AddScoped<ICleanupRepository, CleanupRepository>();
+            services.AddScoped<ICleanupService, CleanupService>();
 
             return services;
         }

--- a/api/Jobs/CleanupBackgroundJob.cs
+++ b/api/Jobs/CleanupBackgroundJob.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Options;
+using RevloDB.Configuration;
+using RevloDB.Services;
+
+namespace RevloDB.Jobs
+{
+    public class CleanupBackgroundJob : BackgroundService
+    {
+        private readonly ILogger<CleanupBackgroundJob> _logger;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly CleanupJobOptions _options;
+
+        public CleanupBackgroundJob(
+            ILogger<CleanupBackgroundJob> logger,
+            IServiceProvider serviceProvider,
+            IOptions<CleanupJobOptions> options)
+        {
+            _logger = logger;
+            _serviceProvider = serviceProvider;
+            _options = options.Value;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (!_options.Enabled)
+            {
+                _logger.LogInformation("Cleanup job is disabled via configuration");
+                return;
+            }
+
+            _logger.LogInformation("Cleanup job started. Will run every {Hours} hours",
+                _options.IntervalHours);
+
+            await Task.Delay(TimeSpan.FromMinutes(_options.StartDelayMinutes), stoppingToken);
+            _logger.LogInformation("Initial delay of {Minutes} minutes completed. Starting cleanup tasks.", _options.StartDelayMinutes);
+
+            if (!stoppingToken.IsCancellationRequested)
+            {
+                await ExecuteCleanupTask();
+            }
+
+            using var timer = new PeriodicTimer(TimeSpan.FromHours(_options.IntervalHours));
+
+            while (!stoppingToken.IsCancellationRequested &&
+                   await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                await ExecuteCleanupTask();
+            }
+        }
+
+        private async Task ExecuteCleanupTask()
+        {
+            try
+            {
+                _logger.LogInformation("Starting scheduled cleanup task at {Time}", DateTime.UtcNow);
+
+                using var scope = _serviceProvider.CreateScope();
+                var cleanupService = scope.ServiceProvider.GetRequiredService<ICleanupService>();
+
+                var result = await cleanupService.ExecuteCleanupAsync();
+
+                if (result.Success)
+                {
+                    if (_options.LogDetailedInfo)
+                    {
+                        _logger.LogInformation("Cleanup task completed successfully. " +
+                            "Deleted: {Count} keys, Duration: {Duration}ms",
+                            result.DeletedKeysCount, result.Duration.TotalMilliseconds);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Cleanup task completed. Deleted {Count} keys", result.DeletedKeysCount);
+                    }
+                }
+                else
+                {
+                    _logger.LogError("Cleanup task failed: {Error}", result.ErrorMessage);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error during cleanup task execution");
+            }
+        }
+
+        public override async Task StopAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("Cleanup job is stopping");
+            await base.StopAsync(stoppingToken);
+        }
+    }
+}

--- a/api/Migrations/20250824080438_AddIsDeletedForKeys.Designer.cs
+++ b/api/Migrations/20250824080438_AddIsDeletedForKeys.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RevloDB.Data;
@@ -11,9 +12,11 @@ using RevloDB.Data;
 namespace api.Migrations
 {
     [DbContext(typeof(RevloDbContext))]
-    partial class RevloDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250824080438_AddIsDeletedForKeys")]
+    partial class AddIsDeletedForKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20250824080438_AddIsDeletedForKeys.cs
+++ b/api/Migrations/20250824080438_AddIsDeletedForKeys.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsDeletedForKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_deleted",
+                table: "keys",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_keys_is_deleted_true",
+                table: "keys",
+                column: "is_deleted",
+                filter: "is_deleted = TRUE");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_keys_is_deleted_true",
+                table: "keys");
+
+            migrationBuilder.DropColumn(
+                name: "is_deleted",
+                table: "keys");
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -1,4 +1,5 @@
 using RevloDB.Extensions;
+using RevloDB.Jobs;
 using RevloDB.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -12,10 +13,14 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddRevloDbServices(builder.Configuration);
 builder.Services.AddRevloDbCors();
 
+// Register the background job
+builder.Services.AddHostedService<CleanupBackgroundJob>();
+
 var app = builder.Build();
 
 // Initialize database
 await app.InitializeDatabaseAsync();
+
 
 // Add the global exception middleware
 app.UseMiddleware<GlobalExceptionMiddleware>();

--- a/api/Repositories/CleanupRepository.cs
+++ b/api/Repositories/CleanupRepository.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using RevloDB.Data;
+using RevloDB.Repositories.Interfaces;
+
+namespace RevloDB.Repositories
+{
+    public class CleanupRepository : ICleanupRepository
+    {
+        private readonly RevloDbContext _context;
+        private readonly ILogger<CleanupRepository> _logger;
+
+        public CleanupRepository(RevloDbContext context, ILogger<CleanupRepository> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<int> GetMarkedKeysCountAsync()
+        {
+            return await _context.Keys.CountAsync(k => k.IsDeleted);
+        }
+
+        public async Task<int> DeleteMarkedKeysAsync()
+        {
+            await _context.Keys
+                .Where(k => k.IsDeleted)
+                .ExecuteUpdateAsync(s => s.SetProperty(k => k.CurrentVersionId, k => null));
+            var deletedCount = await _context.Keys
+                .Where(k => k.IsDeleted)
+                .ExecuteDeleteAsync();
+
+            _logger.LogDebug("Deleted {Count} keys with their versions", deletedCount);
+
+            return deletedCount;
+        }
+    }
+}

--- a/api/Repositories/CleanupRepository.cs
+++ b/api/Repositories/CleanupRepository.cs
@@ -15,19 +15,19 @@ namespace RevloDB.Repositories
             _logger = logger;
         }
 
-        public async Task<int> GetMarkedKeysCountAsync()
+        public async Task<int> GetMarkedKeysCountAsync(CancellationToken cancellationToken = default)
         {
-            return await _context.Keys.CountAsync(k => k.IsDeleted);
+            return await _context.Keys.CountAsync(k => k.IsDeleted, cancellationToken);
         }
 
-        public async Task<int> DeleteMarkedKeysAsync()
+        public async Task<int> DeleteMarkedKeysAsync(CancellationToken cancellationToken = default)
         {
             await _context.Keys
                 .Where(k => k.IsDeleted)
-                .ExecuteUpdateAsync(s => s.SetProperty(k => k.CurrentVersionId, k => null));
+                .ExecuteUpdateAsync(s => s.SetProperty(k => k.CurrentVersionId, k => null), cancellationToken);
             var deletedCount = await _context.Keys
                 .Where(k => k.IsDeleted)
-                .ExecuteDeleteAsync();
+                .ExecuteDeleteAsync(cancellationToken);
 
             _logger.LogDebug("Deleted {Count} keys with their versions", deletedCount);
 

--- a/api/Repositories/Interfaces/ICleanupRepository.cs
+++ b/api/Repositories/Interfaces/ICleanupRepository.cs
@@ -1,0 +1,8 @@
+namespace RevloDB.Repositories.Interfaces
+{
+    public interface ICleanupRepository
+    {
+        Task<int> DeleteMarkedKeysAsync();
+        Task<int> GetMarkedKeysCountAsync();
+    }
+}

--- a/api/Repositories/Interfaces/ICleanupRepository.cs
+++ b/api/Repositories/Interfaces/ICleanupRepository.cs
@@ -1,8 +1,9 @@
+using System.Threading;
 namespace RevloDB.Repositories.Interfaces
 {
     public interface ICleanupRepository
     {
-        Task<int> DeleteMarkedKeysAsync();
-        Task<int> GetMarkedKeysCountAsync();
+        Task<int> DeleteMarkedKeysAsync(CancellationToken cancellationToken = default);
+        Task<int> GetMarkedKeysCountAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/api/Repositories/Interfaces/IKeyRepository.cs
+++ b/api/Repositories/Interfaces/IKeyRepository.cs
@@ -1,16 +1,17 @@
 using RevloDB.Entities;
-using Version = RevloDB.Entities.Version;
 
 namespace RevloDB.Repositories.Interfaces
 {
     public interface IKeyRepository
     {
+        Task<Key> CreateKeyWithVersionAsync(string keyName, string value);
         Task<Key?> GetByIdAsync(int id);
         Task<Key?> GetByNameAsync(string keyName);
-        Task<IEnumerable<Key>> GetAllAsync();
         Task<bool> DeleteByNameAsync(string keyName);
-        Task<bool> ExistsAsync(string keyName);
-        Task<Key> CreateKeyWithVersionAsync(string keyName, string value);
+        Task<bool> RestoreByNameAsync(string keyName);
+        Task<IEnumerable<Key>> GetAllAsync();
         Task<Key> AddNewVersionAsync(string keyName, string value);
+        Task<bool> ExistsAsync(string keyName);
+        Task<Key> RevertToVersionAsync(string keyName, int targetVersionNumber);
     }
 }

--- a/api/Services/CleanupService.cs
+++ b/api/Services/CleanupService.cs
@@ -1,0 +1,65 @@
+using System.Diagnostics;
+using RevloDB.Repositories.Interfaces;
+
+namespace RevloDB.Services
+{
+    public class CleanupService : ICleanupService
+    {
+        private readonly ICleanupRepository _cleanupRepository;
+        private readonly ILogger<CleanupService> _logger;
+
+        public CleanupService(ICleanupRepository cleanupRepository, ILogger<CleanupService> logger)
+        {
+            _cleanupRepository = cleanupRepository;
+            _logger = logger;
+        }
+
+        public async Task<CleanupResult> ExecuteCleanupAsync()
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                var initialCount = await _cleanupRepository.GetMarkedKeysCountAsync();
+                _logger.LogInformation("Starting cleanup. Found {Count} keys marked for deletion", initialCount);
+
+                if (initialCount == 0)
+                {
+                    return new CleanupResult
+                    {
+                        Success = true,
+                        DeletedKeysCount = 0,
+                        Duration = stopwatch.Elapsed
+                    };
+                }
+
+                var deletedCount = await _cleanupRepository.DeleteMarkedKeysAsync();
+
+                stopwatch.Stop();
+
+                _logger.LogInformation("Cleanup completed successfully. Deleted {Count} keys in {Duration}ms",
+                    deletedCount, stopwatch.ElapsedMilliseconds);
+
+                return new CleanupResult
+                {
+                    Success = true,
+                    DeletedKeysCount = deletedCount,
+                    Duration = stopwatch.Elapsed
+                };
+            }
+            catch (Exception ex)
+            {
+                stopwatch.Stop();
+                _logger.LogError(ex, "Error occurred during cleanup execution");
+
+                return new CleanupResult
+                {
+                    Success = false,
+                    DeletedKeysCount = 0,
+                    Duration = stopwatch.Elapsed,
+                    ErrorMessage = ex.Message
+                };
+            }
+        }
+    }
+}

--- a/api/Services/CleanupService.cs
+++ b/api/Services/CleanupService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using RevloDB.Repositories.Interfaces;
+using RevloDB.Services.Interfaces;
 
 namespace RevloDB.Services
 {
@@ -14,13 +15,13 @@ namespace RevloDB.Services
             _logger = logger;
         }
 
-        public async Task<CleanupResult> ExecuteCleanupAsync()
+        public async Task<CleanupResult> ExecuteCleanupAsync(CancellationToken cancellationToken = default)
         {
             var stopwatch = Stopwatch.StartNew();
 
             try
             {
-                var initialCount = await _cleanupRepository.GetMarkedKeysCountAsync();
+                var initialCount = await _cleanupRepository.GetMarkedKeysCountAsync(cancellationToken);
                 _logger.LogInformation("Starting cleanup. Found {Count} keys marked for deletion", initialCount);
 
                 if (initialCount == 0)
@@ -33,7 +34,7 @@ namespace RevloDB.Services
                     };
                 }
 
-                var deletedCount = await _cleanupRepository.DeleteMarkedKeysAsync();
+                var deletedCount = await _cleanupRepository.DeleteMarkedKeysAsync(cancellationToken);
 
                 stopwatch.Stop();
 

--- a/api/Services/Interfaces/ICleanupService.cs
+++ b/api/Services/Interfaces/ICleanupService.cs
@@ -1,0 +1,15 @@
+namespace RevloDB.Services
+{
+    public interface ICleanupService
+    {
+        Task<CleanupResult> ExecuteCleanupAsync();
+    }
+
+    public class CleanupResult
+    {
+        public int DeletedKeysCount { get; set; }
+        public TimeSpan Duration { get; set; }
+        public bool Success { get; set; }
+        public string? ErrorMessage { get; set; }
+    }
+}

--- a/api/Services/Interfaces/ICleanupService.cs
+++ b/api/Services/Interfaces/ICleanupService.cs
@@ -1,8 +1,8 @@
-namespace RevloDB.Services
+namespace RevloDB.Services.Interfaces
 {
     public interface ICleanupService
     {
-        Task<CleanupResult> ExecuteCleanupAsync();
+        Task<CleanupResult> ExecuteCleanupAsync(CancellationToken cancellationToken = default);
     }
 
     public class CleanupResult

--- a/api/Services/Interfaces/IKeyValueService.cs
+++ b/api/Services/Interfaces/IKeyValueService.cs
@@ -10,7 +10,10 @@ namespace RevloDB.Services.Interfaces
         Task<KeyDto> CreateKeyAsync(CreateKeyDto createKeyDto);
         Task<KeyDto> UpdateKeyAsync(string keyName, UpdateKeyDto updateKeyDto);
         Task DeleteKeyAsync(string keyName);
+
+        Task RestoreKeyAsync(string keyName);
         Task<IEnumerable<VersionDto>> GetKeyHistoryAsync(string keyName);
         Task<string?> GetValueAtVersionAsync(string keyName, int versionNumber);
+        Task<KeyDto> RevertKeyAsync(RevertKeyDto revertKeyDto);
     }
 }

--- a/api/Services/KeyValueService.cs
+++ b/api/Services/KeyValueService.cs
@@ -90,6 +90,15 @@ namespace RevloDB.Services
             }
         }
 
+        public async Task RestoreKeyAsync(string keyName)
+        {
+            var restored = await _keyRepository.RestoreByNameAsync(keyName);
+            if (!restored)
+            {
+                throw new KeyNotFoundException($"Key '{keyName}' not found or is not deleted");
+            }
+        }
+
         public async Task<IEnumerable<VersionDto>> GetKeyHistoryAsync(string keyName)
         {
             var key = await _keyRepository.GetByNameAsync(keyName);
@@ -118,6 +127,20 @@ namespace RevloDB.Services
             var version = versions.FirstOrDefault(v => v.VersionNumber == versionNumber);
 
             return version?.Value;
+        }
+
+        public async Task<KeyDto> RevertKeyAsync(RevertKeyDto revertKeyDto)
+        {
+            var revertedKey = await _keyRepository.RevertToVersionAsync(revertKeyDto.KeyName, revertKeyDto.VersionNumber);
+
+            return new KeyDto
+            {
+                Id = revertedKey.Id,
+                KeyName = revertedKey.KeyName,
+                CurrentValue = revertedKey.CurrentVersion?.Value,
+                CurrentVersionNumber = revertedKey.CurrentVersion?.VersionNumber,
+                CreatedAt = revertedKey.CreatedAt
+            };
         }
     }
 }

--- a/api/Services/KeyValueService.cs
+++ b/api/Services/KeyValueService.cs
@@ -1,5 +1,4 @@
 using RevloDB.DTOs;
-using RevloDB.Entities;
 using RevloDB.Repositories.Interfaces;
 using RevloDB.Services.Interfaces;
 
@@ -131,7 +130,7 @@ namespace RevloDB.Services
 
         public async Task<KeyDto> RevertKeyAsync(RevertKeyDto revertKeyDto)
         {
-            var revertedKey = await _keyRepository.RevertToVersionAsync(revertKeyDto.KeyName, revertKeyDto.VersionNumber);
+            var revertedKey = await _keyRepository.RevertToVersionAsync(revertKeyDto.KeyName, revertKeyDto.VersionNumber!.Value);
 
             return new KeyDto
             {

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -10,6 +10,12 @@
     "MaxRetryCount": 3,
     "RetryDelay": 5
   },
+  "CleanupJob": {
+    "Enabled": true,
+    "IntervalHours": 1,
+    "StartDelayMinutes": 1,
+    "LogDetailedInfo": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
- introduces a soft-delete mechanism for keys by adding an IsDeleted flag,
- updates repositories and services to support soft-deletion and restoration
- adds a background cleanup job to permanently remove deleted keys.
- also adds endpoints for restoring and reverting keys to specific version number
- additionally, updates migrations, and configures cleanup job options in appsettings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Restore previously deleted keys via a new API endpoint.
  - Revert a key to a specific earlier version via a new API endpoint.
  - Soft-delete support for keys, enabling restore and safer removals.
  - Automatic scheduled cleanup of deleted keys via a background job.
  - Configurable cleanup settings (enable, interval, start delay, detailed logging).

- Chores
  - CI linter workflow now uses default logging level (reduced verbosity).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->